### PR TITLE
feat(php8): optional parameters after required

### DIFF
--- a/symphony/content/content.blueprintsdatasources.php
+++ b/symphony/content/content.blueprintsdatasources.php
@@ -1655,7 +1655,7 @@ class contentBlueprintsDatasources extends ResourcesPage
      *  Returns an array with the 'data' if it is a valid URL, otherwise a string
      *  containing an error message.
      */
-    public static function __isValidURL($url, $timeout = 6, &$error)
+    public static function __isValidURL($url, &$error, $timeout = 6)
     {
         if (!filter_var($url, FILTER_VALIDATE_URL)) {
             $error = __('Invalid URL');

--- a/symphony/content/content.blueprintspages.php
+++ b/symphony/content/content.blueprintspages.php
@@ -674,11 +674,11 @@ class contentBlueprintsPages extends AdministrationPage
             if (trim($fields['type']) != '' && preg_match('/(index|404|403)/i', $fields['type'])) {
                 $types = preg_split('/\s*,\s*/', strtolower($fields['type']), -1, PREG_SPLIT_NO_EMPTY);
 
-                if (in_array('index', $types) && PageManager::hasPageTypeBeenUsed($page_id, 'index')) {
+                if (in_array('index', $types) && PageManager::hasPageTypeBeenUsed('index', $page_id)) {
                     $this->_errors['type'] = __('An index type page already exists.');
-                } elseif (in_array('404', $types) && PageManager::hasPageTypeBeenUsed($page_id, '404')) {
+                } elseif (in_array('404', $types) && PageManager::hasPageTypeBeenUsed('404', $page_id,)) {
                     $this->_errors['type'] = __('A 404 type page already exists.');
-                } elseif (in_array('403', $types) && PageManager::hasPageTypeBeenUsed($page_id, '403')) {
+                } elseif (in_array('403', $types) && PageManager::hasPageTypeBeenUsed('403', $page_id)) {
                     $this->_errors['type'] = __('A 403 type page already exists.');
                 }
             }
@@ -892,7 +892,7 @@ class contentBlueprintsPages extends AdministrationPage
                     Symphony::ExtensionManager()->notifyMembers('PageTypePreCreate', '/blueprints/pages/', array('page_id' => $page_id, 'types' => &$types));
 
                     // Assign page types:
-                    PageManager::addPageTypesToPage($page_id, $types);
+                    PageManager::addPageTypesToPage($types, $page_id);
 
                     // Find and update children:
                     if ($this->_context[0] == 'edit') {

--- a/symphony/lib/toolkit/class.field.php
+++ b/symphony/lib/toolkit/class.field.php
@@ -595,7 +595,7 @@ class Field
      * @return XMLElement
      *    An XMLElement representing a `<select>` field containing the options.
      */
-    public function buildFormatterSelect($selected = null, $name = 'fields[format]', $label_value)
+    public function buildFormatterSelect($label_value, $selected = null, $name = 'fields[format]')
     {
         $formatters = TextformatterManager::listAll();
 

--- a/symphony/lib/toolkit/class.pagemanager.php
+++ b/symphony/lib/toolkit/class.pagemanager.php
@@ -87,7 +87,7 @@ class PageManager
      * @throws DatabaseException
      * @return boolean
      */
-    public static function addPageTypesToPage($page_id = null, array $types)
+    public static function addPageTypesToPage(array $types, $page_id = null)
     {
         if (is_null($page_id)) {
             return false;
@@ -771,7 +771,7 @@ class PageManager
      * @return boolean
      *  true if the type is used, false otherwise
      */
-    public static function hasPageTypeBeenUsed($page_id = null, $type)
+    public static function hasPageTypeBeenUsed($type, $page_id = null)
     {
         return (boolean)Symphony::Database()->fetchRow(0, sprintf(
             "SELECT

--- a/symphony/lib/toolkit/events/class.event.section.php
+++ b/symphony/lib/toolkit/events/class.event.section.php
@@ -265,7 +265,7 @@ abstract class SectionEvent extends Event
                 }
 
                 // Execute the event for this entry
-                if (!$this->__doit($fields, $entry, $position, $entry_id)) {
+                if (!$this->__doit($entry, $fields, $position, $entry_id)) {
                     $success = false;
                 }
 
@@ -278,7 +278,7 @@ abstract class SectionEvent extends Event
                 $entry_id = $post['id'];
             }
 
-            $success = $this->__doit($fields, $result, null, $entry_id);
+            $success = $this->__doit($result, $fields, null, $entry_id);
         }
 
         if ($success && isset($_REQUEST['redirect'])) {
@@ -308,7 +308,7 @@ abstract class SectionEvent extends Event
      * @return XMLElement
      *  The result of the Event
      */
-    public function __doit(array $fields = array(), XMLElement &$result, $position = null, $entry_id = null)
+    public function __doit(XMLElement &$result, array $fields = array(), $position = null, $entry_id = null)
     {
         $post_values = new XMLElement('post-values');
 

--- a/symphony/lib/toolkit/fields/field.textarea.php
+++ b/symphony/lib/toolkit/fields/field.textarea.php
@@ -108,7 +108,7 @@ class fieldTextarea extends Field implements ExportableField, ImportableField
 
         $div = new XMLElement('div', null, array('class' => 'two columns'));
         $div->appendChild($label);
-        $div->appendChild($this->buildFormatterSelect($this->get('formatter'), 'fields['.$this->get('sortorder').'][formatter]', __('Text Formatter')));
+        $div->appendChild($this->buildFormatterSelect(__('Text Formatter'), $this->get('formatter'), 'fields['.$this->get('sortorder').'][formatter]'));
         $wrapper->appendChild($div);
 
         // Requirements and table display


### PR DESCRIPTION
I was still getting some deprecated errors on the frontend and in the admin.
This fixed it.


PHP 8.0: Deprecate required parameters after optional parameters in function/method signatures

More info:
https://php.watch/versions/8.0/deprecate-required-param-after-optional

